### PR TITLE
Use sys.version_info to determine Python version

### DIFF
--- a/winpython/py3compat.py
+++ b/winpython/py3compat.py
@@ -21,8 +21,8 @@ from __future__ import print_function
 import sys
 import os
 
-PY2 = sys.version[0] == '2'
-PY3 = sys.version[0] == '3'
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
 
 
 # =============================================================================


### PR DESCRIPTION
The string `sys.version` should not be used to determine the Python version as there's no guarantee the Python version is at the beginning of the string. The constant `sys.version_info` should be used instead.
