### PR TITLE
changed osp.dirname() to osp.dirname(osp.abspath())

### DIFF
--- a/make.py
+++ b/make.py
@@ -109,7 +109,7 @@ def replace_in_nsis_file(fname, data):
 
 def build_nsis(srcname, dstname, data):
     """Build NSIS script"""
-    portable_dir = osp.join(osp.dirname(__file__), 'portable')
+    portable_dir = osp.join(osp.dirname(osp.abspath(__file__)), 'portable')
     shutil.copy(osp.join(portable_dir, srcname), dstname)
     data = [('!addincludedir', osp.join(portable_dir, 'include'))
             ] + list(data)
@@ -263,7 +263,7 @@ Name | Version | Description
     @property
     def toolsdirs(self):
         """Return tools directory list"""
-        return [osp.join(osp.dirname(__file__), 'tools')] + self._toolsdirs
+        return [osp.join(osp.dirname(osp.abspath(__file__)), 'tools')] + self._toolsdirs
 
     def get_package_fname(self, pattern):
         """Get package matching pattern in instdir"""
@@ -302,7 +302,7 @@ Name | Version | Description
                         args=None, workdir=None, settingspath=None):
         """Create exe launcher with NSIS"""
         assert name.endswith('.exe')
-        portable_dir = osp.join(osp.dirname(__file__), 'portable')
+        portable_dir = osp.join(osp.dirname(osp.abspath(__file__)), 'portable')
         icon_fname = osp.join(portable_dir, 'icons', icon)
         assert osp.isfile(icon_fname)
 
@@ -365,7 +365,7 @@ call %~dp0env.bat
     def create_installer(self):
         """Create installer with NSIS"""
         self._print("Creating WinPython installer")
-        portable_dir = osp.join(osp.dirname(__file__), 'portable')
+        portable_dir = osp.join(osp.dirname(osp.abspath(__file__)), 'portable')
         fname = osp.join(portable_dir, 'installer-tmp.nsi')
         data = (('DISTDIR', self.winpydir),
                 ('ARCH', self.winpy_arch),
@@ -867,7 +867,7 @@ def rebuild_winpython(basedir=None, verbose=False, archis=(32, 64)):
         for name in os.listdir(packdir):
             if name.startswith('winpython-') and name.endswith('.exe'):
                 os.remove(osp.join(packdir, name))
-        utils.build_wininst(osp.dirname(__file__), copy_to=packdir,
+        utils.build_wininst(osp.dirname(osp.abspath(__file__)), copy_to=packdir,
                             architecture=architecture, verbose=verbose)
 
 


### PR DESCRIPTION
Build fails on win7-amd64 with python3.4.2 when started from BASEDIR with 
python make.py
due to missing root path on subprocess call in utils.py:build_wininst(...)

This fix ensures that the full path is submitted.
