### PR TITLE
correction from rc1

### DIFF
--- a/changelogs/WinPython-2.7.8.2.txt
+++ b/changelogs/WinPython-2.7.8.2.txt
@@ -23,7 +23,7 @@ Name | Version | Description
 [colorama](http://pypi.python.org/pypi/colorama) | 0.3.2 | Cross-platform colored terminal text
 [cvxopt](http://abel.ee.ucla.edu/cvxopt) | 1.1.7 | Convex optimization library
 [cx_Freeze](http://cx-freeze.sourceforge.net) | 4.3.3 | Deployment tool which converts Python scripts into stand-alone Windows executables (i.e. target machine does not require Python or any other library to be installed)
-[Cython](http://www.cython.org) | 0.21 | Cython is a language that makes writing C extensions for the Python language as easy as Python
+[Cython](http://www.cython.org) | 0.21.1 | Cython is a language that makes writing C extensions for the Python language as easy as Python
 [decorator](http://pypi.python.org/pypi/decorator) | 3.4.0 | Better living through Python with decorators
 [docutils](http://docutils.sourceforge.net) | 0.12 | Text processing system for processing plaintext documentation into useful formats, such as HTML or LaTeX (includes reStructuredText)
 [formlayout](http://formlayout.googlecode.com) | 1.0.15 | Module for creating form dialogs/widgets to edit various type of parameters without having to write any GUI code
@@ -43,7 +43,7 @@ Name | Version | Description
 [lxml](http://pypi.python.org/pypi/lxml) | 3.4.0 | Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.
 [mahotas](http://pypi.python.org/pypi/mahotas) | 1.2.1 | Computer Vision library
 [MarkupSafe](http://pypi.python.org/pypi/MarkupSafe) | 0.23 | Implements a XML/HTML/XHTML Markup safe string for Python
-[matplotlib](http://matplotlib.sourceforge.net) | 1.4.0 | 2D plotting library (embeddable in GUIs created with PyQt)
+[matplotlib](http://matplotlib.sourceforge.net) | 1.4.1 | 2D plotting library (embeddable in GUIs created with PyQt)
 [mpld3](http://pypi.python.org/pypi/mpld3) | 0.2 | D3 Viewer for Matplotlib
 [mysql-connector-python](http://pypi.python.org/pypi/mysql-connector-python) | 1.2.3 | MySQL driver written in Python
 [networkx](http://pypi.python.org/pypi/networkx) | 1.9.1 | Python package for creating and manipulating graphs and networks
@@ -53,7 +53,7 @@ Name | Version | Description
 [numba](http://pypi.python.org/pypi/numba) | 0.15.1 | compiling Python code using LLVM
 [numexpr](http://code.google.com/p/numexpr) | 2.4 | Fast evaluation of array expressions elementwise by using a vector-based virtual machine
 [numpy-MKL](http://numpy.scipy.org/) | 1.8.2 | NumPy: multidimensional array processing for numbers, strings, records and objects (SciPy''s core module)
-[pandas](http://pypi.python.org/pypi/pandas) | 0.14.1 | Powerful data structures for data analysis, time series and statistics
+[pandas](http://pypi.python.org/pypi/pandas) | 0.15.0 | Powerful data structures for data analysis, time series and statistics
 [patsy](http://pypi.python.org/pypi/patsy) | 0.3.0 | Describing statistical models using symbolic formulas
 [pep8](http://pypi.python.org/pypi/pep8) | 1.5.7 | Python style guide checker
 [pg8000](http://pypi.python.org/pypi/pg8000) | 1.10.1 | PostgreSQL interface library

--- a/changelogs/WinPython-2.7.8.2_History.txt
+++ b/changelogs/WinPython-2.7.8.2_History.txt
@@ -25,7 +25,7 @@ New packages:
 
 Upgraded packages:
 
-  * [Cython](http://www.cython.org) 0.20.2 → 0.21 (Cython is a language that makes writing C extensions for the Python language as easy as Python)
+  * [Cython](http://www.cython.org) 0.20.2 → 0.21.1 (Cython is a language that makes writing C extensions for the Python language as easy as Python)
   * [Pillow](http://pypi.python.org/pypi/Pillow) 2.5.2 → 2.6.1 (Python Imaging Library (fork))
   * [SQLAlchemy](http://www.sqlalchemy.org) 0.9.7 → 0.9.8 (SQL Toolkit and Object Relational Mapper)
   * [Sphinx](http://sphinx.pocoo.org) 1.2.2 → 1.2.3 (Tool for generating documentation which uses reStructuredText as its markup language)
@@ -37,10 +37,11 @@ Upgraded packages:
   * [joblib](http://pypi.python.org/pypi/joblib) 0.8.2 → 0.8.3_r1 (Lightweight pipelining: using Python functions as pipeline jobs.)
   * [julia](http://sourceforge.net/projects/stonebig.u/files/packages) 0.1.1.2 → 0.1.1.4 (Python interface to the Julia language)
   * [logilab-common](http://pypi.python.org/pypi/logilab-common) 0.61.0 → 0.62.1 (Collection of low-level Python packages and modules used by Logilab projects (required for pylint))
-  * [matplotlib](http://matplotlib.sourceforge.net) 1.3.1 → 1.4.0 (2D plotting library (embeddable in GUIs created with PyQt))
+  * [matplotlib](http://matplotlib.sourceforge.net) 1.3.1 → 1.4.1 (2D plotting library (embeddable in GUIs created with PyQt))
   * [mysql-connector-python](http://pypi.python.org/pypi/mysql-connector-python) 1.2.2 → 1.2.3 (MySQL driver written in Python)
   * [networkx](http://pypi.python.org/pypi/networkx) 1.9 → 1.9.1 (Python package for creating and manipulating graphs and networks)
   * [nose](http://somethingaboutorange.com/mrl/projects/nose) 1.3.3 → 1.3.4 (nose is a discovery-based unittest extension (e.g. NumPy test module is using nose))
+  * [pandas](http://pypi.python.org/pypi/pandas) 0.14.1 → 0.15.0 (Powerful data structures for data analysis, time series and statistics)
   * [pg8000](http://pypi.python.org/pypi/pg8000) 1.9.14 → 1.10.1 (PostgreSQL interface library)
   * [pylint](http://www.logilab.org/project/pylint) 1.3.0 → 1.3.1 (Logilab code analysis module: analyzes Python source code looking for bugs and signs of poor quality)
   * [pyparsing](http://pyparsing.wikispaces.com/) 2.0.2 → 2.0.3 (A Python Parsing Module)

--- a/changelogs/WinPython-3.3.5.2.txt
+++ b/changelogs/WinPython-3.3.5.2.txt
@@ -22,7 +22,7 @@ Name | Version | Description
 [colorama](http://pypi.python.org/pypi/colorama) | 0.3.2 | Cross-platform colored terminal text
 [cvxopt](http://abel.ee.ucla.edu/cvxopt) | 1.1.7 | Convex optimization library
 [cx_Freeze](http://cx-freeze.sourceforge.net) | 4.3.3 | Deployment tool which converts Python scripts into stand-alone Windows executables (i.e. target machine does not require Python or any other library to be installed)
-[Cython](http://www.cython.org) | 0.21 | Cython is a language that makes writing C extensions for the Python language as easy as Python
+[Cython](http://www.cython.org) | 0.21.1 | Cython is a language that makes writing C extensions for the Python language as easy as Python
 [decorator](http://pypi.python.org/pypi/decorator) | 3.4.0 | Better living through Python with decorators
 [docutils](http://docutils.sourceforge.net) | 0.12 | Text processing system for processing plaintext documentation into useful formats, such as HTML or LaTeX (includes reStructuredText)
 [formlayout](http://formlayout.googlecode.com) | 1.0.15 | Module for creating form dialogs/widgets to edit various type of parameters without having to write any GUI code
@@ -42,7 +42,7 @@ Name | Version | Description
 [lxml](http://pypi.python.org/pypi/lxml) | 3.4.0 | Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.
 [mahotas](http://pypi.python.org/pypi/mahotas) | 1.2.1 | Computer Vision library
 [MarkupSafe](http://pypi.python.org/pypi/MarkupSafe) | 0.23 | Implements a XML/HTML/XHTML Markup safe string for Python
-[matplotlib](http://matplotlib.sourceforge.net) | 1.4.0 | 2D plotting library (embeddable in GUIs created with PyQt)
+[matplotlib](http://matplotlib.sourceforge.net) | 1.4.1 | 2D plotting library (embeddable in GUIs created with PyQt)
 [mpld3](http://pypi.python.org/pypi/mpld3) | 0.2 | D3 Viewer for Matplotlib
 [mysql-connector-python](http://pypi.python.org/pypi/mysql-connector-python) | 1.2.3 | MySQL driver written in Python
 [networkx](http://pypi.python.org/pypi/networkx) | 1.9.1 | Python package for creating and manipulating graphs and networks
@@ -51,7 +51,7 @@ Name | Version | Description
 [numba](http://pypi.python.org/pypi/numba) | 0.15.1 | compiling Python code using LLVM
 [numexpr](http://code.google.com/p/numexpr) | 2.4 | Fast evaluation of array expressions elementwise by using a vector-based virtual machine
 [numpy-MKL](http://numpy.scipy.org/) | 1.8.2 | NumPy: multidimensional array processing for numbers, strings, records and objects (SciPy''s core module)
-[pandas](http://pypi.python.org/pypi/pandas) | 0.14.1 | Powerful data structures for data analysis, time series and statistics
+[pandas](http://pypi.python.org/pypi/pandas) | 0.15.0 | Powerful data structures for data analysis, time series and statistics
 [patsy](http://pypi.python.org/pypi/patsy) | 0.3.0 | Describing statistical models using symbolic formulas
 [pep8](http://pypi.python.org/pypi/pep8) | 1.5.7 | Python style guide checker
 [pg8000](http://pypi.python.org/pypi/pg8000) | 1.10.1 | PostgreSQL interface library

--- a/changelogs/WinPython-3.3.5.2_History.txt
+++ b/changelogs/WinPython-3.3.5.2_History.txt
@@ -25,7 +25,7 @@ New packages:
 
 Upgraded packages:
 
-  * [Cython](http://www.cython.org) 0.20.2 → 0.21 (Cython is a language that makes writing C extensions for the Python language as easy as Python)
+  * [Cython](http://www.cython.org) 0.20.2 → 0.21.1 (Cython is a language that makes writing C extensions for the Python language as easy as Python)
   * [Pillow](http://pypi.python.org/pypi/Pillow) 2.5.2 → 2.6.1 (Python Imaging Library (fork))
   * [SQLAlchemy](http://www.sqlalchemy.org) 0.9.7 → 0.9.8 (SQL Toolkit and Object Relational Mapper)
   * [Sphinx](http://sphinx.pocoo.org) 1.2.2 → 1.2.3 (Tool for generating documentation which uses reStructuredText as its markup language)
@@ -37,10 +37,11 @@ Upgraded packages:
   * [joblib](http://pypi.python.org/pypi/joblib) 0.8.2 → 0.8.3_r1 (Lightweight pipelining: using Python functions as pipeline jobs.)
   * [julia](http://sourceforge.net/projects/stonebig.u/files/packages) 0.1.1.2 → 0.1.1.4 (Python interface to the Julia language)
   * [logilab-common](http://pypi.python.org/pypi/logilab-common) 0.61.0 → 0.62.1 (Collection of low-level Python packages and modules used by Logilab projects (required for pylint))
-  * [matplotlib](http://matplotlib.sourceforge.net) 1.3.1 → 1.4.0 (2D plotting library (embeddable in GUIs created with PyQt))
+  * [matplotlib](http://matplotlib.sourceforge.net) 1.3.1 → 1.4.1 (2D plotting library (embeddable in GUIs created with PyQt))
   * [mysql-connector-python](http://pypi.python.org/pypi/mysql-connector-python) 1.2.2 → 1.2.3 (MySQL driver written in Python)
   * [networkx](http://pypi.python.org/pypi/networkx) 1.9 → 1.9.1 (Python package for creating and manipulating graphs and networks)
   * [nose](http://somethingaboutorange.com/mrl/projects/nose) 1.3.3 → 1.3.4 (nose is a discovery-based unittest extension (e.g. NumPy test module is using nose))
+  * [pandas](http://pypi.python.org/pypi/pandas) 0.14.1 → 0.15.0 (Powerful data structures for data analysis, time series and statistics)
   * [pg8000](http://pypi.python.org/pypi/pg8000) 1.9.14 → 1.10.1 (PostgreSQL interface library)
   * [pylint](http://www.logilab.org/project/pylint) 1.3.0 → 1.3.1 (Logilab code analysis module: analyzes Python source code looking for bugs and signs of poor quality)
   * [pyparsing](http://pyparsing.wikispaces.com/) 2.0.2 → 2.0.3 (A Python Parsing Module)

--- a/changelogs/WinPython-3.4.2.1.txt
+++ b/changelogs/WinPython-3.4.2.1.txt
@@ -11,7 +11,6 @@ Name | Version | Description
 [TortoiseHg](http://tortoisehg.bitbucket.org) | 2.11.2 | Set of graphical tools and a shell extension for the Mercurial distributed revision control system
 [MinGW32](http://pypi.python.org/pypi/MinGW32) | 4.8.1 | C/C++ and Fortran compilers (http://www.mingw.org for 32-bit) (https://github.com/numpy/numpy/wiki/Mingw-static-toolchain for 64bit)
 
-
 ### Python packages
 
 Name | Version | Description
@@ -23,7 +22,7 @@ Name | Version | Description
 [colorama](http://pypi.python.org/pypi/colorama) | 0.3.2 | Cross-platform colored terminal text
 [cvxopt](http://abel.ee.ucla.edu/cvxopt) | 1.1.7 | Convex optimization library
 [cx_Freeze](http://cx-freeze.sourceforge.net) | 4.3.3 | Deployment tool which converts Python scripts into stand-alone Windows executables (i.e. target machine does not require Python or any other library to be installed)
-[Cython](http://www.cython.org) | 0.21 | Cython is a language that makes writing C extensions for the Python language as easy as Python
+[Cython](http://www.cython.org) | 0.21.1 | Cython is a language that makes writing C extensions for the Python language as easy as Python
 [decorator](http://pypi.python.org/pypi/decorator) | 3.4.0 | Better living through Python with decorators
 [docutils](http://docutils.sourceforge.net) | 0.12 | Text processing system for processing plaintext documentation into useful formats, such as HTML or LaTeX (includes reStructuredText)
 [formlayout](http://formlayout.googlecode.com) | 1.0.15 | Module for creating form dialogs/widgets to edit various type of parameters without having to write any GUI code
@@ -43,7 +42,7 @@ Name | Version | Description
 [lxml](http://pypi.python.org/pypi/lxml) | 3.4.0 | Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.
 [mahotas](http://pypi.python.org/pypi/mahotas) | 1.2.1 | Computer Vision library
 [MarkupSafe](http://pypi.python.org/pypi/MarkupSafe) | 0.23 | Implements a XML/HTML/XHTML Markup safe string for Python
-[matplotlib](http://matplotlib.sourceforge.net) | 1.4.1rc1 | 2D plotting library (embeddable in GUIs created with PyQt)
+[matplotlib](http://matplotlib.sourceforge.net) | 1.4.1 | 2D plotting library (embeddable in GUIs created with PyQt)
 [mpld3](http://pypi.python.org/pypi/mpld3) | 0.2 | D3 Viewer for Matplotlib
 [mysql-connector-python](http://pypi.python.org/pypi/mysql-connector-python) | 1.2.3 | MySQL driver written in Python
 [networkx](http://pypi.python.org/pypi/networkx) | 1.9.1 | Python package for creating and manipulating graphs and networks
@@ -52,7 +51,7 @@ Name | Version | Description
 [numba](http://pypi.python.org/pypi/numba) | 0.15.1 | compiling Python code using LLVM
 [numexpr](http://code.google.com/p/numexpr) | 2.4 | Fast evaluation of array expressions elementwise by using a vector-based virtual machine
 [numpy-MKL](http://numpy.scipy.org/) | 1.8.2 | NumPy: multidimensional array processing for numbers, strings, records and objects (SciPy''s core module)
-[pandas](http://pypi.python.org/pypi/pandas) | 0.14.1 | Powerful data structures for data analysis, time series and statistics
+[pandas](http://pypi.python.org/pypi/pandas) | 0.15.0 | Powerful data structures for data analysis, time series and statistics
 [patsy](http://pypi.python.org/pypi/patsy) | 0.3.0 | Describing statistical models using symbolic formulas
 [pep8](http://pypi.python.org/pypi/pep8) | 1.5.7 | Python style guide checker
 [pg8000](http://pypi.python.org/pypi/pg8000) | 1.10.1 | PostgreSQL interface library

--- a/changelogs/WinPython-3.4.2.1_History.txt
+++ b/changelogs/WinPython-3.4.2.1_History.txt
@@ -6,7 +6,7 @@ The following changes were made to WinPython distribution since version 3.4.1.1.
 
 New packages:
 
-  * [MinGW32]() 4.8.1 C/C++ and Fortran compilers (http://www.mingw.org for 32-bit) (https://github.com/numpy/numpy/wiki/Mingw-static-toolchain for 64bit)
+  * [MinGW32](http://pypi.python.org/pypi/MinGW32) 4.8.1 (C/C++ and Fortran compilers (http://www.mingw.org for 32-bit) (https://github.com/numpy/numpy/wiki/Mingw-static-toolchain for 64bit))
 
 ### Python packages
 
@@ -30,7 +30,7 @@ New packages:
 
 Upgraded packages:
 
-  * [Cython](http://www.cython.org) 0.20.2 → 0.21 (Cython is a language that makes writing C extensions for the Python language as easy as Python)
+  * [Cython](http://www.cython.org) 0.20.2 → 0.21.1 (Cython is a language that makes writing C extensions for the Python language as easy as Python)
   * [Pillow](http://pypi.python.org/pypi/Pillow) 2.5.2 → 2.6.1 (Python Imaging Library (fork))
   * [Python](http://www.python.org/) 3.4.1 → 3.4.2 (Python programming language with standard library)
   * [SQLAlchemy](http://www.sqlalchemy.org) 0.9.7 → 0.9.8 (SQL Toolkit and Object Relational Mapper)
@@ -43,10 +43,11 @@ Upgraded packages:
   * [joblib](http://pypi.python.org/pypi/joblib) 0.8.2 → 0.8.3_r1 (Lightweight pipelining: using Python functions as pipeline jobs.)
   * [julia](http://sourceforge.net/projects/stonebig.u/files/packages) 0.1.1.2 → 0.1.1.4 (Python interface to the Julia language)
   * [logilab-common](http://pypi.python.org/pypi/logilab-common) 0.61.0 → 0.62.1 (Collection of low-level Python packages and modules used by Logilab projects (required for pylint))
-  * [matplotlib](http://matplotlib.sourceforge.net) 1.3.1 → 1.4.1rc1 (2D plotting library (embeddable in GUIs created with PyQt))
+  * [matplotlib](http://matplotlib.sourceforge.net) 1.3.1 → 1.4.1 (2D plotting library (embeddable in GUIs created with PyQt))
   * [mysql-connector-python](http://pypi.python.org/pypi/mysql-connector-python) 1.2.2 → 1.2.3 (MySQL driver written in Python)
   * [networkx](http://pypi.python.org/pypi/networkx) 1.9 → 1.9.1 (Python package for creating and manipulating graphs and networks)
   * [nose](http://somethingaboutorange.com/mrl/projects/nose) 1.3.3 → 1.3.4 (nose is a discovery-based unittest extension (e.g. NumPy test module is using nose))
+  * [pandas](http://pypi.python.org/pypi/pandas) 0.14.1 → 0.15.0 (Powerful data structures for data analysis, time series and statistics)
   * [pg8000](http://pypi.python.org/pypi/pg8000) 1.9.14 → 1.10.1 (PostgreSQL interface library)
   * [pylint](http://www.logilab.org/project/pylint) 1.3.0 → 1.3.1 (Logilab code analysis module: analyzes Python source code looking for bugs and signs of poor quality)
   * [pyparsing](http://pyparsing.wikispaces.com/) 2.0.2 → 2.0.3 (A Python Parsing Module)


### PR DESCRIPTION
matplotlib 1.4.1rc1 was only in python3.4 versions.
sphinx in python2.7 versions was made with erroneous Sphinx-1.2.3-py3-none-any.whl

==> Re-spin with  : 
- matplolib 1.4.1 final,
- Sphinx-1.2.3-py3-none-any.whl for python 2.7 versions,
- cython 0.21.1 bug fix, released last night,
- pandas 15.0 "recommanded upgrade", released last night.
