### PR TITLE
jupyterlab error in  WinPythonQt5-64bit-3.5.3.1 changelog

### DIFF
--- a/changelogs/WinPythonQt5-64bit-3.5.3.1.md
+++ b/changelogs/WinPythonQt5-64bit-3.5.3.1.md
@@ -102,7 +102,6 @@ Name | Version | Description
 [jupyter_client](https://pypi.python.org/pypi/jupyter_client) | 5.0.0 | Jupyter protocol implementation and client libraries
 [jupyter_console](https://pypi.python.org/pypi/jupyter_console) | 5.1.0 | Jupyter terminal console
 [jupyter_core](https://pypi.python.org/pypi/jupyter_core) | 4.3.0 | Jupyter core package. A base package on which Jupyter projects rely.
-[jupyterlab](https://pypi.python.org/pypi/jupyterlab) | 0.18.1 | Jupyter lab environment notebook server extension
 [keras](https://pypi.python.org/pypi/keras) | 2.0.2 | Theano-based Deep Learning library
 [lasagne](https://pypi.python.org/pypi/lasagne) | 0.2.dev1 | neural network tools for Theano
 [lazy_object_proxy](https://pypi.python.org/pypi/lazy_object_proxy) | 1.2.2 | A fast and thorough lazy object proxy.

--- a/changelogs/WinPythonQt5-64bit-3.5.3.1_History.md
+++ b/changelogs/WinPythonQt5-64bit-3.5.3.1_History.md
@@ -11,7 +11,6 @@ New packages:
   * [comtypes](https://pypi.python.org/pypi/comtypes) 1.1.3 (Pure Python COM package)
   * [edward](https://pypi.python.org/pypi/edward) 1.2.4 (A library for probabilistic modeling, inference, and criticism. Deep generative models, variational inference. Runs on TensorFlow.)
   * [gmpy2](https://pypi.python.org/pypi/gmpy2) 2.0.8 (GMP/MPIR, MPFR, and MPC interface to Python 2.6+ and 3.x)
-  * [jupyterlab](https://pypi.python.org/pypi/jupyterlab) 0.18.1 (Jupyter lab environment notebook server extension)
   * [packaging](https://pypi.python.org/pypi/packaging) 16.8 (Core utilities for Python packages)
   * [protobuf](https://pypi.python.org/pypi/protobuf) 3.2.0 (Protocol Buffers - Google's data interchange format)
   * [pywavelets](https://pypi.python.org/pypi/pywavelets) 0.5.2 (Wavelet transforms module)


### PR DESCRIPTION
noticed by LucK in thread  https://groups.google.com/forum/#!topic/winpython/2WOGqUQSDEU

Jupyterlab-0.18.1 is not in WinPythonQt5-64bit-3.5.3.1

users wanting Jupyterlab will need to:
- launch "WinPython Command Prompt.exe"
- type "pip install jupyterlab"