### PR TITLE
reduce default path length

### DIFF
--- a/make.py
+++ b/make.py
@@ -189,7 +189,7 @@ class WinPythonDistribution(object):
         python_desc = 'Python programming language with standard library'
         return """## WinPython %s 
 
-The following packages are included in WinPython-%s v%s%s.
+The following packages are included in WinPython-%sbit v%s%s.
 
 ### Tools
 
@@ -220,7 +220,7 @@ Name | Version | Description
     @property
     def winpy_arch(self):
         """Return WinPython architecture"""
-        return '%dbit' % self.distribution.architecture
+        return '%d' % self.distribution.architecture
 
     @property
     def pyqt_arch(self):

--- a/portable/installer.nsi
+++ b/portable/installer.nsi
@@ -34,8 +34,8 @@ SetCompressorDictSize 16 ; MB
 ; General
 ;------------------------------------------------------------------------------
 Name "${ID} ${ARCH} ${VERSION}${RELEASELEVEL}"
-OutFile "${DISTDIR}\..\${ID}-${ARCH}-${VERSION}${RELEASELEVEL}.exe"
-InstallDir "$EXEDIR\${ID}-${ARCH}-${VERSION}${RELEASELEVEL}"
+OutFile "${DISTDIR}\..\${ID}${ARCH}-${VERSION}${RELEASELEVEL}.exe"
+InstallDir "$EXEDIR\${ID}${ARCH}-${VERSION}${RELEASELEVEL}"
 BrandingText "${BRANDING}"
 XPStyle on
 RequestExecutionLevel user

--- a/portable/installer.nsi
+++ b/portable/installer.nsi
@@ -18,6 +18,7 @@ Licensed under the terms of the MIT License
 ;================================================================
 
 !define ID "WinPython"
+!define ID_INSTALL "WinPy"
 !define FILE_DESCRIPTION "${ID} Installer"
 !define COMPANY "${ID}"
 !define BRANDING "${ID}, the portable Python Distribution for Scientists"
@@ -35,7 +36,10 @@ SetCompressorDictSize 16 ; MB
 ;------------------------------------------------------------------------------
 Name "${ID} ${ARCH} ${VERSION}${RELEASELEVEL}"
 OutFile "${DISTDIR}\..\${ID}${ARCH}-${VERSION}${RELEASELEVEL}.exe"
-InstallDir "$EXEDIR\${ID}${ARCH}-${VERSION}${RELEASELEVEL}"
+
+; 2018-03-31 need to minimize path length of installation:
+;InstallDir "$EXEDIR\${ID}${ARCH}-${VERSION}${RELEASELEVEL}"
+InstallDir "$EXEDIR\${ID_INSTALL}${ARCH}-${VERSION}${RELEASELEVEL}"
 BrandingText "${BRANDING}"
 XPStyle on
 RequestExecutionLevel user

--- a/winpython/__init__.py
+++ b/winpython/__init__.py
@@ -28,6 +28,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 """
 
-__version__ = '1.9.20180301'
+__version__ = '1.9.20180331'
 __license__ = __doc__
 __project_url__ = 'http://winpython.github.io/'


### PR DESCRIPTION
as nodejs is requiring nearly the whole 256 character length

users may install winpython on a short path from their base letter: `e:\Winp`  for example