### PR TITLE
Update spyder-related links and descriptions in packages.ini

### DIFF
--- a/winpython/data/packages.ini
+++ b/winpython/data/packages.ini
@@ -1537,7 +1537,7 @@ description=Sphinx API for Web Apps
 description=ReadTheDocs.org theme for Sphinx, 2013 version.
 
 [spyder]
-description=Scientific PYthon Development EnviRonment: designed for interactive computing and data visualisation with a simple and intuitive user interface
+description=The Scientific Python Development Environment: An IDE designed for interactive computing and data visualisation with a simple and intuitive user interface
 
 [spyder_kernels]
 description=Jupyter kernels for the Spyder console
@@ -1546,19 +1546,19 @@ description=Jupyter kernels for the Spyder console
 description=Jupyter notebook integration with Spyder
 
 [spyder_reports]
-description=pyder plugin to render Markdown reports using Pweave as a backend
+description=Spyder plugin to render Markdown reports using Pweave as a backend
 
 [spyder_terminal]
-description=Spyder Plugin for displaying a virtual terminal (OS independent) inside the main Spyder window
+description=Spyder plugin for displaying a virtual terminal (OS independent) inside the main Spyder window
 
 [spyder.line_profiler]
-description=a plugin to run the python line profiler from within the spyder editor
+description=A plugin to run the Python line profiler from within the Spyder editor
 
 [spyder.memory_profiler]
-description=a plugin to run the python memory_profiler from within the spyder editor.
+description=A plugin to run the Python memory_profiler from within the Spyder editor
 
 [spyder.autopep8]
-description=A plugin to run the autopep8 python linter from within the spyder editor
+description=A plugin to run the autopep8 Python linter from within the Spyder editor
 
 [sqlalchemy]
 description=SQL Toolkit and Object Relational Mapper

--- a/winpython/data/packages.ini
+++ b/winpython/data/packages.ini
@@ -309,7 +309,7 @@ description=Python exposure of DyND
 
 [egenix-mx-base]
 description=eGenix.com mx Base Distribution: mxDateTime, mxTextTools, mxProxy, mxBeeBase, mxURL, mxUID, mxStack, mxQueue and mxTools
-url=http://www.egenix.com/products/python/mxBase    
+url=http://www.egenix.com/products/python/mxBase
 category=util
 
 [ecos]
@@ -719,7 +719,7 @@ description=Metakernel for Jupyter
 
 [mingwpy]
 description=the python friendly windows compiler toolchain
-url=https://anaconda.org/carlkl/mingwpy   
+url=https://anaconda.org/carlkl/mingwpy
 
 [mistune]
 description=The fastest markdown parser in pure Python, inspired by marked.
@@ -728,7 +728,7 @@ description=The fastest markdown parser in pure Python, inspired by marked.
 description=Scales for Python
 
 [mkl-service]
-description=Python bindings to some MKL service functions 
+description=Python bindings to some MKL service functions
 url=https://github.com/ContinuumIO/mkl-service
 
 [mock]
@@ -781,7 +781,7 @@ description=better multiprocessing and multithreading in python
 
 [mxbase]
 description=eGenix.com mx Base Distribution: mxDateTime, mxTextTools, mxProxy, mxBeeBase, mxURL, mxUID, mxStack, mxQueue and mxTools
-url=http://www.egenix.com/products/python/mxBase    
+url=http://www.egenix.com/products/python/mxBase
 category=util
 
 [mysql-connector-python]
@@ -942,7 +942,7 @@ description=pure Python library that reads and writes PDFs
 description=Pandas plotting interface to Vega and Vega-Lite
 
 [peewee]
-description=a small, expressive ORM. 
+description=a small, expressive ORM.
 
 [pep8]
 description=Python style guide checker
@@ -983,10 +983,10 @@ description=Python plotting library for collaborative, interactive, publication-
 description=A grammar of graphics for python
 
 [plotpy]
-description=plotpy is a set of tools for curve and image plotting 
+description=plotpy is a set of tools for curve and image plotting
 
 [pluggy]
-description=plugin and hook calling mechanisms for python 
+description=plugin and hook calling mechanisms for python
 
 [ply]
 description=Python Lex & Yacc
@@ -1493,7 +1493,7 @@ description=Python 2 and 3 compatibility utilities
 category=util
 
 [sklearn-theano]
-description=Scikit-learn compatible tools using theano 
+description=Scikit-learn compatible tools using theano
 
 [skll]
 description=SciKit-Learn Laboratory makes it easier to run machinelearning experiments with scikit-learn.

--- a/winpython/data/packages.ini
+++ b/winpython/data/packages.ini
@@ -1321,6 +1321,7 @@ description=Jupyter Qt console
 
 [qtpy]
 description=Provides an abstraction layer on top of the various Qt bindings (PyQt5, PyQt4 and PySide) and additional custom QWidgets.
+url=https://github.com/spyder-ide/qtpy
 
 [qscintilla]
 description=Python bindings for the QScintilla programmers editor widget
@@ -1538,27 +1539,35 @@ description=ReadTheDocs.org theme for Sphinx, 2013 version.
 
 [spyder]
 description=The Scientific Python Development Environment: An IDE designed for interactive computing and data visualisation with a simple and intuitive user interface
+url=https://www.spyder-ide.org/
 
 [spyder_kernels]
 description=Jupyter kernels for the Spyder console
+url=https://github.com/spyder-ide/spyder-kernels
 
 [spyder_notebook]
 description=Jupyter notebook integration with Spyder
+url=https://github.com/spyder-ide/spyder-notebook
 
 [spyder_reports]
 description=Spyder plugin to render Markdown reports using Pweave as a backend
+url=https://github.com/spyder-ide/spyder-reports
 
 [spyder_terminal]
 description=Spyder plugin for displaying a virtual terminal (OS independent) inside the main Spyder window
+url=https://github.com/spyder-ide/spyder-terminal
 
 [spyder.line_profiler]
 description=A plugin to run the Python line profiler from within the Spyder editor
+url=https://github.com/spyder-ide/spyder-line-profiler
 
 [spyder.memory_profiler]
 description=A plugin to run the Python memory_profiler from within the Spyder editor
+url=https://github.com/spyder-ide/spyder-memory-profiler
 
 [spyder.autopep8]
 description=A plugin to run the autopep8 Python linter from within the Spyder editor
+url=https://github.com/spyder-ide/spyder-autopep8
 
 [sqlalchemy]
 description=SQL Toolkit and Object Relational Mapper


### PR DESCRIPTION
Similar to winpython/winpython.github.io#61 and per spyder-ide/spyder-docs#39 ; 

* I've updated the Spyder project descriptions a bit and did some minor cleanup (mainly capatilization-related
* I've also added links for each under the ``url`` property for each since I see other packages have that.
* Trailing whitespace cleanup

Again, if there's a problem with either of the second two commits, let me know and I'll fix or revert/drop them. I didn't do the HTTPS conversion here since it seemed a bit more out of scope.

Also, @stonebig I wanted to get your input before I did anything but can we update the latest version of each of the changelogs with the link to the actual spyder website instead of just PyPI (as most of the other big packages have) and the updated full name/description? Or at least make sure it gets updated in the next version of all of them? Figure you'd know much better than I the best way to handle this.

Thanks!
