### PR TITLE
Ensure compatibility with pyqt5-tools > 5.9.0

### DIFF
--- a/make.py
+++ b/make.py
@@ -1166,6 +1166,8 @@ cd/D "%WINPYWORKDIR%"
 if "%QT_API%"=="pyqt5" (
     if exist "%WINPYDIR%\Lib\site-packages\pyqt5-tools\designer.exe" (
         "%WINPYDIR%\Lib\site-packages\pyqt5-tools\designer.exe" %*
+    ) else if exist "%WINPYDIR%\Lib\site-packages\pyqt5_tools\designer.exe" (
+        "%WINPYDIR%\Lib\site-packages\pyqt5_tools\designer.exe" %*
     ) else (
         "%WINPYDIR%\Lib\site-packages\PyQt5\designer.exe" %*
     )
@@ -1182,6 +1184,8 @@ cd/D "%WINPYWORKDIR%"
 if "%QT_API%"=="pyqt5" (
     if exist "%WINPYDIR%\Lib\site-packages\pyqt5-tools\assistant.exe" (
         "%WINPYDIR%\Lib\site-packages\pyqt5-tools\assistant.exe" %*
+    ) else if exist "%WINPYDIR%\Lib\site-packages\pyqt5_tools\assistant.exe" (
+        "%WINPYDIR%\Lib\site-packages\pyqt5_tools\assistant.exe" %*
     ) else (
         "%WINPYDIR%\Lib\site-packages\PyQt5\assistant.exe" %*
     )
@@ -1196,6 +1200,8 @@ cd/D "%WINPYWORKDIR%"
 if "%QT_API%"=="pyqt5" (
     if exist "%WINPYDIR%\Lib\site-packages\pyqt5-tools\linguist.exe" (
         "%WINPYDIR%\Lib\site-packages\pyqt5-tools\linguist.exe" %*
+    ) else if exist "%WINPYDIR%\Lib\site-packages\pyqt5_tools\linguist.exe" (
+        "%WINPYDIR%\Lib\site-packages\pyqt5_tools\linguist.exe" %*
     ) else (
         cd/D "%WINPYDIR%\Lib\site-packages\PyQt5"
         "%WINPYDIR%\Lib\site-packages\PyQt5\linguist.exe" %*


### PR DESCRIPTION
In pyqt5-tools newer than 5.9.0.* the install path has changed from site-packages\pyqt5-tools to site-packages\pyqt5_tools. This is a fix to check also for the new loction in qtdesigner.bat, qtlinguist.bat and qtassistant.bat.