### PR TITLE
Remove the typing module

### DIFF
--- a/winpython/data/packages.ini
+++ b/winpython/data/packages.ini
@@ -1817,9 +1817,6 @@ description=Actively maintained, pure Python wrapper for the Twitter API. Suppor
 [typed_ast]
 description=a fork of Python 2 and 3 ast modules with type comment support
 
-[typing]
-description=Type Hints for Python
-
 [tzlocal]
 description=tzinfo object for the local timezone
 


### PR DESCRIPTION
Remove the typing module since this is a standard python library since 3.5 and it seems to conflict with python 3.7.

See https://docs.python.org/3/library/typing.html and this [appveyor build failure](https://ci.appveyor.com/project/ericpre/hyperspy-bundle/builds/19660402/job/gs9l31okjhplckur).