### PR TITLE
no more needed workaround for spyder3-3.3.3 and PyQt5-5.12.1 icon issue

### DIFF
--- a/winpython/wppm.py
+++ b/winpython/wppm.py
@@ -483,11 +483,6 @@ python "%~dpn0""" + ext + """" %*""")
               r"\Lib\site-packages\spyder\config\main.py"),
               "'check_updates_on_startup': True,",
               "'check_updates_on_startup': False,")
-            utils.patch_sourcefile(
-              self.target + (
-              r"\Lib\site-packages\spyder\config\main.py"),
-              "'icon_theme': 'spyder 3'",
-              "'icon_theme': 'spyder 2'")
 
         # workaround bad installers
         if package_name.lower() == "numba":


### PR DESCRIPTION
will allow to have usual icons for Spyder 3