### PR TITLE
Configure JUPYTER_CONFIG_DIR and JUPYTER_CONFIG_PATH

### DIFF
--- a/make.py
+++ b/make.py
@@ -1011,6 +1011,8 @@ rem read https://github.com/winpython/winpython/issues/839
 rem set USERPROFILE=%HOME%
 rem set WINPYDIRBASE=
 set JUPYTER_DATA_DIR=%HOME%
+set JUPYTER_CONFIG_DIR=%WINPYDIR%\etc\jupyter
+set JUPYTER_CONFIG_PATH=%WINPYDIR%\etc\jupyter
 set WINPYARCH=WIN32
 if  "%WINPYDIR:~-5%"=="amd64" set WINPYARCH=WIN-AMD64
 set FINDDIR=%WINDIR%\system32


### PR DESCRIPTION
This defines the environment variables JUPYTER_CONFIG_DIR and JUPYTER_CONFIG_PATH which are described [here](https://jupyter.readthedocs.io/en/latest/use/jupyter-directories.html?#configuration-files).

They are set to `%WINPYDIR%\etc\jupyter` with this PR. 

On Windows Jupyter searches for configuration files in `%PROGRAMDATA%\jupyter\` and `C:\Users\Username\.jupyter` first, if the variables above are not defined. If one also has a "regular" Jupyter installation using these directories, the winpython environment may load configuration files from these locations and cause issues. 
Apart from that, the winpython environment might place files here, which affects portability.

In my USB drive installation of winpython I also created an empty file in 
`%WINPYDIR%\etc\jupyter\jupyter_notebook_config.py` 
but I am not certain this is necessary. This will cause Jupyter to "find" a configuration file and not search any further. 

Calling `jupyter --paths` will still list directories on C:, but at the end of the search queue.
