### PR TITLE
Add aditional path to check for qt binaries

### DIFF
--- a/make.py
+++ b/make.py
@@ -1763,6 +1763,8 @@ if "%QT_API%"=="" ( set QT_API=pyqt5 )
 if "%QT_API%"=="pyqt5" (
     if exist "%WINPYDIR%\Scripts\designer.exe" (
         "%WINPYDIR%\Scripts\designer.exe" %*
+    ) else if exist "%WINPYDIR%\Lib\site-packages\qt5_applications\Qt\bin\designer.exe" (
+        "%WINPYDIR%\Lib\site-packages\qt5_applications\Qt\bin\designer.exe" %*
     ) else if exist "%WINPYDIR%\Lib\site-packages\pyqt5_tools\Qt\bin\designer.exe" (
         "%WINPYDIR%\Lib\site-packages\pyqt5_tools\Qt\bin\designer.exe" %*
     ) else if exist "%WINPYDIR%\Lib\site-packages\pyqt5-tools\designer.exe" (
@@ -1787,6 +1789,8 @@ if "%QT_API%"=="" ( set QT_API=pyqt5 )
 if "%QT_API%"=="pyqt5" (
     if exist "%WINPYDIR%\Scripts\assistant.exe" (
         "%WINPYDIR%\Scripts\assistant.exe" %*
+    ) else if exist "%WINPYDIR%\Lib\site-packages\qt5_applications\Qt\bin\assistant.exe" (
+        "%WINPYDIR%\Lib\site-packages\qt5_applications\Qt\bin\assistant.exe" %*
     ) else if exist "%WINPYDIR%\Lib\site-packages\pyqt5_tools\Qt\bin\assistant.exe" (
         "%WINPYDIR%\Lib\site-packages\pyqt5_tools\Qt\bin\assistant.exe" %*
     ) else if exist "%WINPYDIR%\Lib\site-packages\pyqt5-tools\assistant.exe" (
@@ -1811,6 +1815,8 @@ if "%QT_API%"=="" ( set QT_API=pyqt5 )
 if "%QT_API%"=="pyqt5" (
     if exist "%WINPYDIR%\Scripts\linguist.exe" (
         "%WINPYDIR%\Scripts\linguist.exe" %*
+    ) else if exist "%WINPYDIR%\Lib\site-packages\qt5_applications\Qt\bin\linguist.exe" (
+        "%WINPYDIR%\Lib\site-packages\qt5_applications\Qt\bin\linguist.exe" %*
     ) else if exist "%WINPYDIR%\Lib\site-packages\pyqt5_tools\Qt\bin\linguist.exe" (
         "%WINPYDIR%\Lib\site-packages\pyqt5_tools\Qt\bin\linguist.exe" %*
     ) else if exist "%WINPYDIR%\Lib\site-packages\pyqt5-tools\linguist.exe" (


### PR DESCRIPTION
Binaries designer, assistant, linguist are located in package 'qt_applications' using pyqt5_tools 5.15.2
Similar to [PR#881](https://github.com/winpython/winpython/pull/881)