### PR TITLE
Remove pycc from list of commands to create batch files for

### DIFF
--- a/winpython/wppm.py
+++ b/winpython/wppm.py
@@ -622,7 +622,7 @@ python "%~dpn0"""
             )
         # workaround bad installers
         if package_name.lower() == "numba":
-            self.create_pybat(['numba', 'pycc'])
+            self.create_pybat(['numba'])
         else:
             self.create_pybat(package_name.lower())
 


### PR DESCRIPTION
The `pycc` script from `numba` will finally be removed after 7 years of being deprecated (see https://github.com/numba/numba/issues/8322 and https://github.com/numba/numba/pull/8335), so this PR removes it from the list of batch files to be created. I'm not sure if this change will be incorporated in the next intermediate release of `numba` (expected to be 0.56.1) or the full release after (expected to be 0.57), so feel free to hold off merging this until the actual `numba` release happens.