### PR TITLE
Handle double quote after `python.exe` in `patch_shebang_line()`

### DIFF
--- a/winpython/utils.py
+++ b/winpython/utils.py
@@ -369,15 +369,15 @@ def patch_shebang_line(
     executable = sys.executable
     if sys.version_info[0] == 2:
         shebang_line = re.compile(
-            r"(#!.*pythonw?\.exe)"
+            r"(#!.*pythonw?\.exe)\"?"
         )  # Python2.7
     else:
         shebang_line = re.compile(
-            b"(#!.*pythonw?\.exe)"
+            b"(#!.*pythonw?\.exe)\"?"
         )  # Python3+
         if 'pypy3' in sys.executable:
             shebang_line = re.compile(
-            b"(#!.*pypy3w?\.exe)"
+            b"(#!.*pypy3w?\.exe)\"?"
         )  # Pypy3+
             
         target_dir = target_dir.encode('utf-8')


### PR DESCRIPTION
Fixes #1426.

Adds optional double quote after `python.exe` to the regex match in `patch_shebang_line()`, outside of the capture group, so that the double quote gets stripped if it exists. Note that any double quotes between `!#` and `python.exe` are already stripped with the existing code.

(By the way, it seems like the shebang line still works without double quotes when the reverse is invoked, i.e., `patch_shebang_line(to_movable=False)`, so this PR does not attempt to add them for that specific case.)