### PR TITLE
Forward arguments from `wpcp.bat` to `wppm`

### DIFF
--- a/portable/scripts/wpcp.bat
+++ b/portable/scripts/wpcp.bat
@@ -1,3 +1,3 @@
 @echo off
 call "%~dp0env_for_icons.bat" %*
-cmd.exe /k "echo wppm & wppm" 
+cmd.exe /k "echo wppm & wppm" %*


### PR DESCRIPTION
Is there a reason not to forward arguments passed to `wpcp.bat`?