### PR TITLE
Remove quotes and .exe from VSCode command when calling from `%PATH%`

### DIFF
--- a/portable/scripts/winvscode.bat
+++ b/portable/scripts/winvscode.bat
@@ -6,5 +6,5 @@ if exist "%WINPYDIR%\..\t\vscode\code.exe" (
 if exist "%LOCALAPPDATA%\Programs\Microsoft VS Code\code.exe" (
     "%LOCALAPPDATA%\Programs\Microsoft VS Code\code.exe"  %*
 ) else (
-    "code.exe" %*
+    code %*
 ))


### PR DESCRIPTION
When VSCode isn't found from the portable folder within WinPython or `%LOCALAPPDATA%`, I understand that `winvscode.bat` tries to implicitly call it from `%PATH%`. However, the batch file calls `"code.exe"`, which doesn't seem to work. Instead, we should just be able to call `code`.