### PR TITLE
Shift `wpcp.bat` forwarded arguments inside quotes

### DIFF
--- a/portable/scripts/wpcp.bat
+++ b/portable/scripts/wpcp.bat
@@ -1,3 +1,3 @@
 @echo off
 call "%~dp0env_for_icons.bat" %*
-cmd.exe /k "echo wppm & wppm" %*
+cmd.exe /k "echo wppm & wppm %*"


### PR DESCRIPTION
Modifies #1571 to shift the arguments inside the quotes, so that the quoted arguments can be used (such as for quoted paths). This is only necessary because `wpcp.bat` uses `cmd.exe /c` to call `wppm` (rather than calling `python -m wppm`).