### PR TITLE
use PyPI trusted publishing (OIDC) instead of API token for wppm prod…

### DIFF
--- a/.github/workflows/build_wppm_prod_publish.yml
+++ b/.github/workflows/build_wppm_prod_publish.yml
@@ -76,6 +76,7 @@ jobs:
     name: Upload to PyPI (prod)
     needs: [build_wheels]
     runs-on: ubuntu-24.04
+    environment: pypi  # must match the environment declared in the PyPI trusted publisher
     permissions:
       # This permission is required for pypi's "trusted publisher" feature
       id-token: write
@@ -88,6 +89,5 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
           verbose: true  # Enable verbose output


### PR DESCRIPTION
… publish