### PR TITLE
fix wppm -p pkg[.] showing only the last extra, and make -p -l0 a true one-liner

### DIFF
--- a/wppm/__init__.py
+++ b/wppm/__init__.py
@@ -28,6 +28,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 """
 
-__version__ = '17.7.20260715'
+__version__ = '17.7.20260716'
 __license__ = __doc__
 __project_url__ = 'http://winpython.github.io/'

--- a/wppm/piptree.py
+++ b/wppm/piptree.py
@@ -246,7 +246,7 @@ class PipData:
                                     verbose=verbose,
                                     upward=upward,
                                 )
-                    elif not upward and (not dependency.get("req_marker") or self._marker_true(dependency["req_marker"], extra)):
+                    elif not upward and len(path) < depth and (not dependency.get("req_marker") or self._marker_true(dependency["req_marker"], extra)):
                         # not there but was required
                         wall_hit += " "
                         ret += [[f'{dependency["req_key"]}==? {dependency["req_version"]}']]
@@ -269,9 +269,10 @@ class PipData:
             if extra == ".":
                 for one_extra in sorted(self.distro[p]["provides"]):
                     a =  self._get_dependency_tree(p, one_extra, version_req, depth, verbose=verbose, ppend=ppend)
+                    results += a if (len(a[0])>1 or ppend=="") else []
             else:
                 a = self._get_dependency_tree(p, extra, version_req, depth, verbose=verbose, ppend=ppend)
-            results += a if (len(a[0])>1 or ppend=="") else []    
+                results += a if (len(a[0])>1 or ppend=="") else []
         rawtext = json.dumps(results, indent=indent)
         lines = [l[2*indent:] for l in rawtext.split("\n") if len(l.strip()) > 2]
         return "\n".join(lines).replace('"', "")

--- a/wppm/wppm.py
+++ b/wppm/wppm.py
@@ -298,7 +298,7 @@ def main(test=False):
         pip = piptree.PipData(targetpython, args.wheelsource)
         for args_fname in args.fname:
             pack, extra, *other = (args_fname + "[").replace("]", "[").split("[")
-            print(pip.down(pack, extra, args.levels if args.levels>0 else 2, verbose=args.verbose))
+            print(pip.down(pack, extra, args.levels if args.levels>=0 else 2, verbose=args.verbose))
         sys.exit()
     elif args.pipup:
         pip = piptree.PipData(targetpython, args.wheelsource)


### PR DESCRIPTION
summary:
- down(): the results accumulation had moved outside the per-extra loop, so only the alphabetically last extra was displayed
- wppm -p -l0 now means depth 0 like wppm -r -l0 (was silently depth 2)
- missing-dependency '==?' lines now respect the requested depth
- bump wppm version to 17.7.20260716

bugs were not from Claude but previous human:
- for the "pandas[.]" showing only 1 extra, it's
````

The bug: commit 5114738 ("display missing dependancies") restructured down() in wppm/piptree.py so it could filter results for the new ! mode, but it moved the results += ... line outside the for one_extra in sorted(self.distro[p]["provides"]) loop. Each iteration overwrote a, and only the last extra in alphabetical order (xml for pandas) was appended to the output. It affected only -p with [.]; up() (-r) kept its accumulation inside the loop, which is why your reverse test was fine.

The fix: moved results += a if (len(a[0])>1 or ppend=="") else [] back inside the loop (and duplicated it in the else branch), at piptree.py:268-275.

One side note from the verification output: the ==? "missing dependency" lines show up even at -l0, since they're emitted at the current level rather than as a recursion — that's the new feature from 5114738 behaving as designed, just mentioning it in case you expected -l0 to stay one-line-per-extra.
````
- for "wppm -p pandas -l0" not showing one line:
  - it was like that since june 2025
  - so having Claude caring of code gives more time to worry on result... if you are still in [needed] perseverance mode.