### PR TITLE
build: drop the duplicate Pre requirements pass

### DIFF
--- a/build_winpython_meta.py
+++ b/build_winpython_meta.py
@@ -59,8 +59,6 @@ def run_build(build, python_versions):
     my_archive_dir = os.path.join(os.getcwd(), "WinPython_build_logs")
     os.makedirs(my_archive_dir, exist_ok=True)
 
-    my_requirements_pre = build.get("my_requirements_pre",  mandatory_requirements)
-
     # Build command
     build_cmd = [
         str(my_python_exe),
@@ -75,7 +73,6 @@ def run_build(build, python_versions):
         "--tools_dirs", my_toolsdirs,
         "--log-dir", my_archive_dir,
         "--mandatory-req", mandatory_requirements,
-        "--pre-req", my_requirements_pre,
         "--requirements", my_requirements,
         "--constraints", my_constraints,
         "--find-links", my_find_links,

--- a/winpython/build_winpython.py
+++ b/winpython/build_winpython.py
@@ -175,7 +175,6 @@ def main():
     parser.add_argument('--find-links', default='wheelhouse', help='Path to local wheelhouse')
     parser.add_argument('--log-dir', default='WinPython_build_logs', help='Directory for logs')
     parser.add_argument('--mandatory-req', help='Mandatory requirements file')
-    parser.add_argument('--pre-req', help='Pre requirements file')
     parser.add_argument('--wheelhousereq', help='Wheelhouse requirements file')
     parser.add_argument('--create-installer', default='', help='default installer to create')
     args = parser.parse_args()
@@ -217,7 +216,6 @@ def main():
 
     for label, req in [
         ("Mandatory", args.mandatory_req),
-        ("Pre", args.pre_req),
         ("Main", args.requirements),
     ]:
         pip_install(target_python, req, args.constraints, args.find_links, label, ["--force-reinstall"])


### PR DESCRIPTION
Step 3 installed three requirement files: Mandatory, Pre, then Main. Pre defaulted to the Mandatory file and nothing ever overrode it -- no [[builds]] entry in winpython_builds_bd13/14/15.toml sets my_requirements_pre, and neither does anything under C:\WinP. So every flavor installed pip, setuptools and wppm twice, both times with --force-reinstall, five flavors per cycle.

Removes the --pre-req argument and the meta script that fed it, rather than leaving dead configurability behind.

Checked by generating all 5 build commands for bd314 with subprocess stubbed out: none carries --pre-req, and each still parses against build_winpython's argument list with zero unknown arguments.