### PR TITLE
ci: draft a cycle-file build workflow (to separate code from parameters)

### DIFF
--- a/.github/scripts/cycle_config.py
+++ b/.github/scripts/cycle_config.py
@@ -1,0 +1,61 @@
+"""Read a cycle TOML and emit its build configuration as GITHUB_OUTPUT lines.
+
+    python .github/scripts/cycle_config.py cycles/2026_03.toml 3.14
+
+Writes to $GITHUB_OUTPUT when set, otherwise stdout, so it can be run locally
+to see exactly what a workflow run would get. tomllib is stdlib from 3.11, and
+GitHub runners are newer than that, so this needs no dependency.
+"""
+import json
+import os
+import sys
+import tomllib
+from pathlib import Path
+
+
+def build_config(cfg: dict, requested: str) -> dict:
+    pythons = cfg["pythons"]
+    if requested not in pythons:
+        raise SystemExit(
+            f"no entry for python {requested!r}; this cycle offers {', '.join(sorted(pythons))}"
+        )
+    entry = pythons[requested]
+
+    # the check the PowerShell version did: ver2's first 3 parts must appear in
+    # the tarball URL, so a copy-paste slip between the two cannot go unnoticed
+    short = ".".join(entry["ver2"].split(".")[:3])
+    if short not in entry["src"]:
+        raise SystemExit(f"{requested}: '{short}' not found in src {entry['src']}")
+
+    return {
+        "ver2": entry["ver2"],
+        "src": entry["src"],
+        "sha": entry["sha"],
+        "cycle_dir": cfg["cycle_dir"],
+        "release_level": cfg.get("release_level", ""),
+        "pandoc_source": cfg["pandoc"]["source"],
+        "pandoc_sha256": cfg["pandoc"]["sha256"],
+        # consumed by the build job as strategy.matrix via fromJSON
+        "matrix": json.dumps({"flavor": cfg["flavors"]}, separators=(",", ":")),
+    }
+
+
+def main(argv: list[str]) -> None:
+    if len(argv) != 3:
+        raise SystemExit(f"usage: {Path(argv[0]).name} <cycle.toml> <python_version>")
+    cfg_path = Path(argv[1])
+    if not cfg_path.is_file():
+        raise SystemExit(f"no such cycle file: {cfg_path}")
+    with cfg_path.open("rb") as fh:
+        cfg = tomllib.load(fh)
+
+    rendered = "".join(f"{k}={v}\n" for k, v in build_config(cfg, argv[2]).items())
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as fh:
+            fh.write(rendered)
+    sys.stdout.write(rendered)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/.github/workflows/build_winpython_cycle.yml
+++ b/.github/workflows/build_winpython_cycle.yml
@@ -1,0 +1,210 @@
+name: Build WinPython (cycle file)
+# Draft, sitting beside github_workflows_build-YYYY_NN.yml for comparison.
+#
+# Same build as those, but everything cycle-specific comes from cycles/<cycle>.toml
+# instead of being copied into a new workflow each time. A new cycle is a new TOML.
+
+on:
+  workflow_dispatch:
+    inputs:
+      cycle:
+        description: 'Build cycle (file name in cycles/, without .toml)'
+        required: true
+        default: '2026_03'
+        type: string
+      python_versionf:
+        description: 'Python version to build; must exist in that cycle file'
+        required: true
+        default: '3.14'
+        type: choice
+        options:
+          - '3.13'
+          - '3.14'
+          - '3.14F'
+          - '3.15'
+          - '3.15F'
+
+env:
+  WINPYARCH: "64"
+  dotwheelhouse: "dotpython\\wheelhouse\\included.wheels"
+
+jobs:
+  config:
+    # reads the cycle file once, instead of once per matrix leg
+    runs-on: ubuntu-latest
+    outputs:
+      ver2: ${{ steps.cfg.outputs.ver2 }}
+      src: ${{ steps.cfg.outputs.src }}
+      sha: ${{ steps.cfg.outputs.sha }}
+      cycle_dir: ${{ steps.cfg.outputs.cycle_dir }}
+      release_level: ${{ steps.cfg.outputs.release_level }}
+      pandoc_source: ${{ steps.cfg.outputs.pandoc_source }}
+      pandoc_sha256: ${{ steps.cfg.outputs.pandoc_sha256 }}
+      matrix: ${{ steps.cfg.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Read cycle configuration
+        id: cfg
+        run: python .github/scripts/cycle_config.py "cycles/${{ inputs.cycle }}.toml" "${{ inputs.python_versionf }}"
+
+  build-winpython:
+    needs: config
+    runs-on: windows-latest
+    strategy:
+      fail-fast: true
+      matrix: ${{ fromJSON(needs.config.outputs.matrix) }}
+
+    env:
+      PYTHON_VERSIONF: ${{ inputs.python_versionf }}
+      WINPYFLAVOR: ${{ matrix.flavor.name }}
+      PANDOC: ${{ matrix.flavor.PANDOC }}
+      WINPYARCHDET: ${{ matrix.flavor.WINPYARCHDET }}
+      my_cycle: ${{ needs.config.outputs.cycle_dir }}
+      my_release_level: ${{ needs.config.outputs.release_level }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set static and matrix variables based on selected Python version
+        shell: pwsh
+        env:
+          PYTHON_VERSIONF: ${{ env.PYTHON_VERSIONF }}
+          WINPYARCHDET: ${{ env.WINPYARCHDET }}
+          WINPYVER2: ${{ needs.config.outputs.ver2 }}
+          my_cycle: ${{ env.my_cycle }}
+          my_release_level: ${{ env.my_release_level }}
+          FLAVOR_NAME: ${{ matrix.flavor.name }}
+        run: |
+          # Normalize PYTHON_VERSION by removing trailing 'F' if present
+          $PYTHON_VERSION = $env:PYTHON_VERSIONF -replace 'F$',''
+          Add-Content -Path $env:GITHUB_ENV -Value "PYTHON_VERSION=$PYTHON_VERSION"
+
+          # Detect architecture (64 or 64F)
+          $detected_arch = if ($env:PYTHON_VERSIONF -like '*F') { '64F' } else { '64' }
+
+          $WINPYVER2 = $env:WINPYVER2
+          $BUILD_LOCATION = "WPy64-" + ($WINPYVER2 -replace '[.]', "")
+          Add-Content -Path $env:GITHUB_ENV -Value "build_location=$BUILD_LOCATION"
+
+          # ver2-vs-source consistency is checked in cycle_config.py
+
+          $WINPYREQUIREMENTS = ''
+          $WINPYREQUIREMENTSwhl = ''
+
+          # Generate requirement files expected names dynamically
+          $V_TAG = $env:WINPYVER2 -replace '\.', '_'
+          $testreq = "$($env:my_cycle)/requir.64-$($V_TAG)$($env:FLAVOR_NAME)$($env:my_release_level).txt"
+          $testwhl = "$($env:my_cycle)/requir.64-$($V_TAG)$($env:FLAVOR_NAME)$($env:my_release_level)_wheels.txt"
+
+          Write-Host "Checking for requirements files: $testreq and $testwhl (expected arch $detected_arch)"
+
+          if ($env:WINPYARCHDET -eq $detected_arch -and (Test-Path $testreq)) {
+            $WINPYREQUIREMENTS = $testreq
+            Write-Host "Found $WINPYREQUIREMENTS"
+            if (Test-Path $testwhl) {
+              $WINPYREQUIREMENTSwhl = $testwhl
+              Write-Host "Found also $WINPYREQUIREMENTSwhl"
+            }
+          }
+
+          Add-Content -Path $env:GITHUB_ENV -Value "WINPYREQUIREMENTS=$WINPYREQUIREMENTS"
+          Add-Content -Path $env:GITHUB_ENV -Value "WINPYREQUIREMENTSwhl=$WINPYREQUIREMENTSwhl"
+
+          $WINPYLOCKFILE = ''
+          $WINPYLOCKFILEwhl = ''
+
+          # Generate pylock files expected names dynamically
+          $testreq = "$($env:my_cycle)/pylock.64-$($V_TAG)$($env:FLAVOR_NAME)$($env:my_release_level).toml"
+          $testwhl = "$($env:my_cycle)/pylock.64-$($V_TAG)$($env:FLAVOR_NAME)$($env:my_release_level)_wheels.toml"
+
+          Write-Host "Checking for pylock files: $testreq and $testwhl (expected arch $detected_arch)"
+
+          if ($env:WINPYARCHDET -eq $detected_arch -and (Test-Path $testreq)) {
+            $WINPYLOCKFILE = $testreq
+            Write-Host "Found $WINPYLOCKFILE"
+            if (Test-Path $testwhl) {
+              $WINPYLOCKFILEwhl = $testwhl
+              Write-Host "Found also $WINPYLOCKFILEwhl"
+            }
+          }
+
+          Add-Content -Path $env:GITHUB_ENV -Value "WINPYLOCKFILE=$WINPYLOCKFILE"
+          Add-Content -Path $env:GITHUB_ENV -Value "WINPYLOCKFILEwhl=$WINPYLOCKFILEwhl"
+
+          $ARTIFACT_NAME = "publish_${PYTHON_VERSION}$($env:FLAVOR_NAME)"
+          Add-Content -Path $env:GITHUB_ENV -Value "ARTIFACT_NAME=$ARTIFACT_NAME"
+
+          $destwheelhouse = "$BUILD_LOCATION\wheelhouse\included.wheels"
+          Add-Content -Path $env:GITHUB_ENV -Value "destwheelhouse=$destwheelhouse"
+
+          $WINPYVER = "${WINPYVER2}$($env:FLAVOR_NAME)$($env:my_release_level)"
+          Add-Content -Path $env:GITHUB_ENV -Value "WINPYVER=$WINPYVER"
+
+          # Store WINPYVER2 in env for later steps
+          Add-Content -Path $env:GITHUB_ENV -Value "WINPYVER2=$WINPYVER2"
+
+      - name: Download, verify and extract python standalone
+        if: env.WINPYLOCKFILE != ''
+        uses: ./.github/actions/python-setup
+        with:
+          python_source: ${{ needs.config.outputs.src }}
+          python_sha256: ${{ needs.config.outputs.sha }}
+          build_location: ${{ env.build_location }}
+
+      - name: Download, checking hash and integrating pandoc binary
+        if: env.WINPYLOCKFILE != '' && env.PANDOC == '1'
+        uses: ./.github/actions/pandoc-setup
+        with:
+          pandoc_source: ${{ needs.config.outputs.pandoc_source }}
+          pandoc_sha256: ${{ needs.config.outputs.pandoc_sha256 }}
+          build_location: ${{ env.build_location }}
+
+      - name: Upgrade pip and patch launchers
+        if: env.WINPYLOCKFILE != ''
+        shell: pwsh
+        run: |
+          & "$env:build_location\python\python.exe" -m pip install --upgrade --force-reinstall pip --no-warn-script-location
+          & "$env:build_location\python\python.exe" -c "from wppm import wppm;dist=wppm.Distribution();dist.patch_standard_packages('pip', to_movable=True)"
+
+      - name: Download all requirements
+        if: ${{ env.WINPYLOCKFILE != '' }}
+        shell: pwsh
+        run: |
+          $py = "$env:build_location\python\python.exe"
+          & $py -m pip download --dest $env:dotwheelhouse --no-deps --require-hashes -r $env:WINPYLOCKFILE
+          if ($env:WINPYLOCKFILEwhl -ne '') {
+              & $py -m pip download --dest $env:destwheelhouse --no-deps --require-hashes -r $env:WINPYLOCKFILEwhl
+          }
+
+      - name: Install lockfile
+        if: env.WINPYLOCKFILE != ''
+        shell: pwsh
+        run: |
+          & "$env:build_location\python\python.exe" -m pip install --no-deps --require-hashes -r $env:WINPYLOCKFILE --no-warn-script-location
+
+      - name: Generate Assets and Hashes
+        if: env.WINPYLOCKFILE != ''
+        uses: ./.github/actions/publish-winpython
+        with:
+          build_location: ${{ env.build_location }}
+          winpy_flavor: ${{ env.WINPYFLAVOR }}
+          winpy_arch: ${{ env.WINPYARCH }}
+          winpy_ver: ${{ env.WINPYVER }}
+          winpy_ver2: ${{ env.WINPYVER2 }}
+          dotwheelhouse: ${{ env.dotwheelhouse }}
+          winpy_requirements_whl: ${{ env.WINPYREQUIREMENTSwhl }}
+          format_zip: ${{ matrix.flavor.formats.zip }}
+          format_7z: ${{ matrix.flavor.formats['7z'] }}
+          format_exe: ${{ matrix.flavor.formats.exe }}
+
+      - name: Upload artifacts
+        if: env.WINPYLOCKFILE != ''
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: publish_output
+          retention-days: 66  # keeps artifact for 66 days

--- a/cycles/2026_03.toml
+++ b/cycles/2026_03.toml
@@ -1,0 +1,72 @@
+# WinPython 2026-03 build cycle.
+#
+# Everything that changes from one cycle to the next lives here, so a new cycle
+# is a new file rather than a copy of the workflow.
+
+cycle_dir     = "winpython/portable/cycle_2026_03"
+release_level = "b3"
+
+[pandoc]
+source = "https://github.com/jgm/pandoc/releases/download/3.1.9/pandoc-3.1.9-windows-x86_64.zip"
+sha256 = "11eb6dbe5286c9e5edb0cca4412e7d99ec6578ec04158b0b7fe11f7fd96688e5"
+
+# The python-build-standalone tarball for each version offered by the workflow.
+# ver2 is the WinPython 4-part version; its first 3 parts must appear in src.
+
+[pythons."3.13"]
+ver2 = "3.13.15.0"
+src  = "https://github.com/astral-sh/python-build-standalone/releases/download/20260807/cpython-3.13.15+20260807-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
+sha  = "44bf9ae71f4b45e3ba3104ae331c6eff3f7002593c26fd12453eb9310c4f259a"
+
+[pythons."3.14"]
+ver2 = "3.14.7.0"
+src  = "https://github.com/astral-sh/python-build-standalone/releases/download/20260807/cpython-3.14.7+20260807-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
+sha  = "840e368318d1630bd8efbd3f7de8fab32cb4bbd735baef733f9034f2676c6a92"
+
+[pythons."3.14F"]
+ver2 = "3.14.7.0"
+src  = "https://github.com/astral-sh/python-build-standalone/releases/download/20260807/cpython-3.14.7+20260807-x86_64-pc-windows-msvc-freethreaded-install_only_stripped.tar.gz"
+sha  = "c8323293c9e76e8b244a0e533894512f067dac2a6aa2dfcb3494cbe74b3af58e"
+
+[pythons."3.15"]
+ver2 = "3.15.0.4"
+src  = "https://github.com/astral-sh/python-build-standalone/releases/download/20260807/cpython-3.15.0rc1+20260807-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
+sha  = "bc0d0f3c7b88873688f30bc78da8387a6653a5493424951d3a84c658c973198e"
+
+[pythons."3.15F"]
+ver2 = "3.15.0.4"
+src  = "https://github.com/astral-sh/python-build-standalone/releases/download/20260807/cpython-3.15.0rc1+20260807-x86_64-pc-windows-msvc-freethreaded-install_only_stripped.tar.gz"
+sha  = "e5998e014f16074ac9f6d61eb2a31ff8ac8bc331b61da2c5acf7d15abf4a2650"
+
+# Flavors become the job matrix. 2026-02 renamed "free" to "dotf", so this
+# varies per cycle too and belongs in the cycle file.
+
+[[flavors]]
+name         = "dot"
+PANDOC       = "0"
+WINPYARCHDET = "64"
+formats      = { zip = true, "7z" = false, exe = true }
+
+[[flavors]]
+name         = "slim"
+PANDOC       = "1"
+WINPYARCHDET = "64"
+formats      = { zip = false, "7z" = true, exe = true }
+
+[[flavors]]
+name         = "whl"
+PANDOC       = "0"
+WINPYARCHDET = "64"
+formats      = { zip = false, "7z" = true, exe = false }
+
+[[flavors]]
+name         = "dotf"
+PANDOC       = "0"
+WINPYARCHDET = "64F"
+formats      = { zip = true, "7z" = false, exe = true }
+
+[[flavors]]
+name         = "slimf"
+PANDOC       = "1"
+WINPYARCHDET = "64F"
+formats      = { zip = false, "7z" = true, exe = true }


### PR DESCRIPTION
Sits beside the per-cycle workflows for comparison; nothing existing is changed. Cycle data moves to cycles/2026_03.toml, so a new cycle is a new file instead of a copy of the workflow.

Verified the TOML reproduces github_workflows_build-2026_03.yml exactly: ver2, src and sha for all five versions, and the five flavors with their formats.