### PR TITLE
initial clean-up and  default security enhancement for new cycle 2026-04

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,8 @@
 
     MIT licence
     
-    Copyright (c) 2012-2014 Pierre Raybaut
-    Copyright (c) 2014-2024+ The Winpython development team https://github.com/winpython/
+    Copyright (c) 2009-2013 Pierre Raybaut
+    Copyright (c) 2014-2026+ The Winpython development team https://github.com/winpython/
 
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 WinPython tools
 ===============
 
-Copyright 2012-2013 Pierre Raybaut
+Copyright 2009-2013 Pierre Raybaut
 
 Copyright 2014-2026+ The Winpython development team: https://github.com/winpython/
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -273,6 +273,9 @@ onnxruntime>=1.23.2
 openai>=2.7.1
 openpyxl>=3.1.5
 opentelemetry-api>=1.34.1
+# 2026-08-30 this project publishes betas only, so the specifier names one.
+# That is what lets pip take it now that the build no longer passes --pre.
+opentelemetry-semantic-conventions>=0.60b1
 optree>=0.17.0
 optuna>=4.2.1
 orjson>=3.11.4

--- a/winpython/build_winpython.py
+++ b/winpython/build_winpython.py
@@ -48,7 +48,11 @@ def pip_install(python_exe: Path, req_file: str, constraints: str, find_links: s
         cmd = [
             str(python_exe), "-m", "pip", "install",
             "-r", req_file, "-c", constraints,
-            "--pre", "--no-index", f"--find-links={find_links}",
+            # No --pre. pip accepts a prerelease when the specifier itself names
+            # one, so a prerelease reaches a build because the constraints ask
+            # for it on that target, not because it happened to be the newest
+            # file in the wheelhouse.
+            "--no-index", f"--find-links={find_links}",
             "--upgrade", "--no-warn-script-location"
         ]
         if options:
@@ -173,7 +177,8 @@ def process_wheelhouse_requirements(target_python: Path, winpydirbase: Path,args
     if wheelhousereq.is_file():
         # Generate pylock from wheelhousereq
         cmd = [
-            str(target_python), "-m", "pip", "lock", "--no-index", "--trusted-host=None", "--pre", 
+            # no --pre here either: same rule as pip_install()
+            str(target_python), "-m", "pip", "lock", "--no-index", "--trusted-host=None",
             "--find-links", args.find_links, "-c", args.constraints, "-r", str(wheelhousereq),
             "-o", str(out)
         ]

--- a/winpython/portable/launchers_building/launchers_final_proposed/license.txt
+++ b/winpython/portable/launchers_building/launchers_final_proposed/license.txt
@@ -13,7 +13,7 @@ following license agreement.
 WinPython License Agreement (MIT License)
 -----------------------------------------
 
-Copyright (c) 2012 Pierre Raybaut, 2016+ WinPython team 
+Copyright (c) 2009-2013 Pierre Raybaut, 2014-2026+ WinPython team 
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/winpython/portable/launchers_building/launchers_src/LICENSE
+++ b/winpython/portable/launchers_building/launchers_src/LICENSE
@@ -8,7 +8,7 @@ DataLab-WinPython is a Python distribution for Windows:
 I. - WinPython License Agreement (MIT License)
 ----------------------------------------------
 
-Copyright (c) 2012 Pierre Raybaut, 2016+ WinPython team 
+Copyright (c) 2009-2013 Pierre Raybaut, 2014-2026+ WinPython team 
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/winpython/portable/launchers_building/launchers_src_original/LICENSE
+++ b/winpython/portable/launchers_building/launchers_src_original/LICENSE
@@ -8,7 +8,7 @@ DataLab-WinPython is a Python distribution for Windows:
 I. - WinPython License Agreement (MIT License)
 ----------------------------------------------
 
-Copyright (c) 2012 Pierre Raybaut, 2016+ WinPython team 
+Copyright (c) 2009-2013 Pierre Raybaut, 2014-2026+ WinPython team 
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/winpython/portable/launchers_final/license.txt
+++ b/winpython/portable/launchers_final/license.txt
@@ -13,7 +13,7 @@ following license agreement.
 WinPython License Agreement (MIT License)
 -----------------------------------------
 
-Copyright (c) 2012 Pierre Raybaut, 2016+ WinPython team 
+Copyright (c) 2009-2013 Pierre Raybaut, 2014-2026+ WinPython team 
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/wppm/__init__.py
+++ b/wppm/__init__.py
@@ -3,7 +3,7 @@
 WinPython License Agreement (MIT License)
 -----------------------------------------
 
-Copyright (c) 2012-2013 Pierre Raybaut
+Copyright (c) 2009-2013 Pierre Raybaut
 Copyright (c) 2014-2026+  The Winpython development team https://github.com/winpython/
 
 Permission is hereby granted, free of charge, to any person


### PR DESCRIPTION
"--pre" packages can still exist, as there may be only  bleeding edge packages from some python-3.15, epsecically in beta cycle, but it must be "stated" for each given package-version.

