### PR TITLE
Put the release level in the changelog name

### DIFF
--- a/.github/actions/publish-winpython/action.yml
+++ b/.github/actions/publish-winpython/action.yml
@@ -13,6 +13,10 @@ inputs:
     required: true
   winpy_ver2:
     required: true
+  release_level:
+    required: false
+    default: ""
+    description: 'b1, rc2, ... appended to winpy_ver2 in the changelog name'
   dotwheelhouse:
     required: true
   winpy_requirements_whl:
@@ -51,8 +55,11 @@ runs:
         $env:PYTHONIOENCODING="utf-8"
         $pythonExe = Join-Path "${{ inputs.build_location }}" "python\python.exe"
 
-        # Markdown Metadata
-        $destfile_md = "publish_output\WinPython${{ inputs.winpy_flavor }}-${{ inputs.winpy_arch }}bit-${{ inputs.winpy_ver2 }}.md" 
+        # Markdown Metadata. The release level is part of the name: a b1 and the
+        # final it becomes share a winpy_ver2, so without it the beta's package
+        # list occupies the final's file. 3.15.0.5b1 is a PEP 440 version, and
+        # sorts where find_previous_version needs it to.
+        $destfile_md = "publish_output\WinPython${{ inputs.winpy_flavor }}-${{ inputs.winpy_arch }}bit-${{ inputs.winpy_ver2 }}${{ inputs.release_level }}.md"
         & $pythonExe -m wppm -md | Out-File -FilePath $destfile_md -Encoding utf8
         gc $destfile_md
 

--- a/.github/workflows/build_winpython_cycle.yml
+++ b/.github/workflows/build_winpython_cycle.yml
@@ -50,6 +50,7 @@ jobs:
     outputs:
       pandoc_source: ${{ steps.cfg.outputs.pandoc_source }}
       pandoc_sha256: ${{ steps.cfg.outputs.pandoc_sha256 }}
+      release_level: ${{ steps.cfg.outputs.release_level }}
       release_tag: ${{ steps.cfg.outputs.release_tag }}
       matrix: ${{ steps.cfg.outputs.matrix }}
     steps:
@@ -158,6 +159,7 @@ jobs:
           winpy_arch: ${{ env.WINPYARCH }}
           winpy_ver: ${{ env.WINPYVER }}
           winpy_ver2: ${{ env.WINPYVER2 }}
+          release_level: ${{ needs.config.outputs.release_level }}
           dotwheelhouse: ${{ env.dotwheelhouse }}
           winpy_requirements_whl: ${{ matrix.leg.requirements_wheels }}
           format_zip: ${{ matrix.leg.formats.zip }}

--- a/tests/test_cycle_config.py
+++ b/tests/test_cycle_config.py
@@ -260,6 +260,19 @@ class TestWorkflowMatchesConfig:
         assert "if: ${{ inputs.publish }}" in workflow_text
         assert "if: ${{ !inputs.publish }}" in workflow_text
 
+    def test_the_changelog_name_carries_the_release_level(self, workflow_text):
+        """A beta and the final it becomes share a ver2.
+
+        Without the level in the name, a b1's package list is written to the
+        file the final release wants, and `changelogs/` briefly describes a
+        beta under the final's name. The level has to reach the composite
+        action for that, so both halves are checked.
+        """
+        assert "release_level: ${{ needs.config.outputs.release_level }}" in workflow_text
+        action = (REPO / ".github/actions/publish-winpython/action.yml").read_text(encoding="utf-8")
+        assert re.search(r"^  release_level:$", action, re.MULTILINE), "action input is missing"
+        assert "${{ inputs.winpy_ver2 }}${{ inputs.release_level }}.md" in action
+
     def test_the_release_tag_is_never_taken_from_a_dispatch_input(self, workflow_text):
         """One source of truth: the cycle file. An input would let them disagree."""
         assert "inputs.release_tag" not in workflow_text

--- a/winpython/build_winpython.py
+++ b/winpython/build_winpython.py
@@ -309,9 +309,13 @@ def main():
     generate_lockfiles(target_python, winpydirbase, args.constraints, args.find_links, file_postfix)
 
 
-    log_section(f"🙏 Step 7: generate changelog") 
-    mdn = f"WinPython{args.flavor}-{args.arch}bit-{winpyver2}.md"
-    out = f"WinPython{args.flavor}-{args.arch}bit-{winpyver2}_History.md"
+    log_section(f"🙏 Step 7: generate changelog")
+    # the release level belongs in the name: a b1 and the final it becomes share
+    # a winpyver2, so without it the beta's package list occupies the final's
+    # file. 3.15.0.5b1 is a PEP 440 version, and sorts where it should.
+    changelog_version = f"{winpyver2}{args.release_level}"
+    mdn = f"WinPython{args.flavor}-{args.arch}bit-{changelog_version}.md"
+    out = f"WinPython{args.flavor}-{args.arch}bit-{changelog_version}_History.md"
     changelog_dir = log_dir.parent/ "changelogs"
     
     cmd = ["set", f"WINPYVER2={winpyver2}&",  "set",  f"WINPYFLAVOR={args.flavor}&",
@@ -328,7 +332,7 @@ def main():
     cmd = [str(target_python), "-X", "utf8", "-c",
         (
         "from wppm import diff;"
-        f"result = diff.compare_package_indexes('{winpyver2}', searchdir=r'{changelog_dir}', flavor=r'{args.flavor}', architecture={args.arch});"
+        f"result = diff.compare_package_indexes('{changelog_version}', searchdir=r'{changelog_dir}', flavor=r'{args.flavor}', architecture={args.arch});"
         f"open(r'{winpydirbase.parent / out}', 'w', encoding='utf-8').write(result)" 
         )]
     run_command(cmd, check=False)


### PR DESCRIPTION
A beta and the final it becomes share a `winpyver2`, so 2026-04 b1's changelog was written as `WinPythonslim-64bit-3.15.0.5.md` — the name the *final* release wants. `changelogs/` would describe a beta under the final's name until the final build overwrote it.

The name now carries the level: **`WinPythonslim-64bit-3.15.0.5b1.md`**. That is a PEP 440 version, and since #2100 it sorts where `find_previous_version` needs it to.

### The consequence, which is the point

Each release now compares against the release immediately before it. The final diffs against its own `b1` rather than reaching back to the previous cycle:

```
final 3.15.0.5 compares against -> 3.15.0.5b1
History: "The following changes were made ... since version 3.15.0.5b1slim"
```

This is a change for finals as well as betas, and it is deliberate: an automatic changelog is more logical when it describes the step from the last published thing, and it makes the b1-to-final delta visible instead of folding it into the cycle total.

### What needed changing

Four places build or read that name; three needed the level.

- `.github/actions/publish-winpython/action.yml` — new `release_level` input, defaulting to `""`.
- `.github/workflows/build_winpython_cycle.yml` — `release_level` is a config job output again, and is passed to the action.
- `winpython/build_winpython.py` — the local build path had the same gap, for both the changelog and its `_History` companion. Both come from one `changelog_version` now, and that same value goes to `compare_package_indexes`; otherwise the diff would look for a file the build no longer writes.
- `wppm/diff.py` — nothing. `load_version_markdown` takes the version it is given, and `find_previous_version` returns levelled ones already.

`pylock`, `requir` and `hashes` carry the level through `winpy_ver` and are untouched.

### Testing

184 passed, including a new check that both halves of the CI path line up — the workflow passing `release_level`, and the action using it in the name.

End-to-end against real changelog content: a directory holding `3.15.0.5b1` and `3.15.0.5` for the slim flavor, run through `write_changelog`, produces the History quoted above and picks the b1 as the baseline.

Note that runs started before this merges still produce the un-levelled name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBk5k7WdpPvx4SUFyEk3U3
